### PR TITLE
Require zip extension

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -9,6 +9,8 @@
     "faq_url": "",
     "support_url": "https://www.themehouse.com/help",
     "extra_urls": [],
-    "require": [],
+    "require": {
+        "zip":["1.0", "PHP Zip Extension"]
+    },
     "icon": "install_upgrade.png"
 }


### PR DESCRIPTION
To avoid weird support requests, probably should just outright require the zip extension.