### PR TITLE
Move job queuing out of installer steps and into postUpgrade 

### DIFF
--- a/Setup.php
+++ b/Setup.php
@@ -62,6 +62,16 @@ class Setup extends AbstractSetup
     /** 1.1.1 */
     use Patch1010130;
 
+    public function postUpgrade($previousVersion, array &$stateChanges)
+    {
+        if ($previousVersion <= 1000040)
+        {
+            $jobManager = \XF::app()->jobManager();
+            $jobManager->enqueue('ThemeHouse\InstallAndUpgrade:ImportTHStyles');
+        }
+    }
+
+
     /** ---- UNINSTALL ---- */
 
     public function uninstallStep4()

--- a/Setup/Patch1000040.php
+++ b/Setup/Patch1000040.php
@@ -2,17 +2,15 @@
 
 namespace ThemeHouse\InstallAndUpgrade\Setup;
 
-use XF\Db\Schema\Alter;
-
 trait Patch1000040
 {
-    public function upgrade1000032Step1()
+    public function upgrade1000040Step1()
     {
         $this->installStep1();
     }
 
-    public function upgrade1000040Step1()
+    public function upgrade1000040Step2()
     {
-        \XF::app()->jobManager()->enqueue('ThemeHouse\InstallAndUpgrade:ImportTHStyles');
+        $this->installStep2();
     }
 }


### PR DESCRIPTION
I've found en-queuing jobs in the installer steps result in unreliable upgrades due to CLI/GUI scheduling differences and `is_processing` handling.