### PR TITLE
php 8.4 compatibility

### DIFF
--- a/InstallAndUpgrade/AbstractHandler.php
+++ b/InstallAndUpgrade/AbstractHandler.php
@@ -55,7 +55,7 @@ abstract class AbstractHandler implements ArrayAccess
      * AbstractHandler constructor.
      * @param Profile|null $profile
      */
-    public function __construct(Profile $profile = null)
+    public function __construct(?Profile $profile = null)
     {
         $this->app = XF::app();
         $this->em = $this->app->em();

--- a/Repository/Log.php
+++ b/Repository/Log.php
@@ -22,7 +22,7 @@ class Log extends Repository
      * @param User|null $user
      * @throws PrintableException
      */
-    public function log(Product $product, $action, $extra = [], User $user = null)
+    public function log(Product $product, $action, $extra = [], ?User $user = null)
     {
         if (!$user) {
             $user = XF::visitor();

--- a/Service/StyleArchive/Extractor.php
+++ b/Service/StyleArchive/Extractor.php
@@ -93,7 +93,7 @@ class Extractor extends AbstractService
      * @param array $failures
      * @return bool
      */
-    public function checkWritable(array $changeset = null, &$failures = [])
+    public function checkWritable(?array $changeset = null, &$failures = [])
     {
         $zip = $this->zip();
         $failures = [];
@@ -153,7 +153,7 @@ class Extractor extends AbstractService
      * @return array
      * @noinspection PhpUnusedParameterInspection
      */
-    public function copyFiles(array $changeset = null, $start = 0, Timer $timer = null)
+    public function copyFiles(?array $changeset = null, $start = 0, ?Timer $timer = null)
     {
         $zip = $this->zip();
         $lastComplete = $start;

--- a/Service/StyleArchive/Installer.php
+++ b/Service/StyleArchive/Installer.php
@@ -43,7 +43,7 @@ class Installer extends AbstractService
      * @param Product $product
      * @param Style|null $parentStyle
      */
-    public function __construct(App $app, $file, Product $product, Style $parentStyle = null)
+    public function __construct(App $app, $file, Product $product, ?Style $parentStyle = null)
     {
         parent::__construct($app);
 
@@ -60,7 +60,7 @@ class Installer extends AbstractService
      * @return array
      * @throws PrintableException
      */
-    public function install(array $xmls, Style $parent = null, array $childXmls = [], $force = false)
+    public function install(array $xmls, ?Style $parent = null, array $childXmls = [], $force = false)
     {
         $response = null;
 
@@ -83,7 +83,7 @@ class Installer extends AbstractService
      * @return array
      * @throws PrintableException
      */
-    protected function installStyle($xml, Style $parent = null, $childXmls = [], $force = false)
+    protected function installStyle($xml, ?Style $parent = null, $childXmls = [], $force = false)
     {
         /** @var Import $styleImporter */
         $styleImporter = $this->service('XF:Style\Import');

--- a/addon.json
+++ b/addon.json
@@ -12,6 +12,10 @@
         "XFRM": "https://xenforo.com/community/resources/install-and-upgrade.6753/"
     },
     "require": {
+        "php": [
+            "7.1.0",
+            "PHP 7.1.0+"
+        ],
         "XF": [
             2010010,
             "XenForo 2.1.0+"


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

Fully fixing this will require updating forking & `thesoftwarefanatics/php-html-parser` which hasn't updated for ~5 years now. 

Note; the php 7.1 minimum version was basically required by  `thesoftwarefanatics/php-html-parser` anyway.